### PR TITLE
results page now hides search fields that were not entered

### DIFF
--- a/views/pages/address-results.ejs
+++ b/views/pages/address-results.ejs
@@ -11,10 +11,18 @@
           <div class="property-container">
             <section>
               <h4>Address Info</h4>
+              <% if (walkScoreInfo[0].address) { %>
               <p class="streetAddress"> Street Address: <%= walkScoreInfo[0].address %></p>
+              <% } %>
+              <% if (walkScoreInfo[0].city) { %>
               <p class="city"> City: <%= walkScoreInfo[0].city %></p>
+              <% } %>
+              <% if (walkScoreInfo[0].state) { %>
               <p class="state"> State: <%= walkScoreInfo[0].state %></p>
+              <% } %>
+              <% if (walkScoreInfo[0].zip) { %>
               <p class="zip"> Zip Code: <%= walkScoreInfo[0].zip %></p>
+              <% } %>
               <h4>WalkScore Info</h4>
               <span>lat: <%= walkScoreInfo[1].snapped_lat %> lon: <%= walkScoreInfo[1].snapped_lon %></span>
               <p class="walk-score-rating"> WalkScore Rating: <%= walkScoreInfo[1].walkscore %></p>

--- a/views/pages/address.ejs
+++ b/views/pages/address.ejs
@@ -10,7 +10,7 @@
       <form id="find-address-info" action="/address" method="post" novalidate>
         <p>
           <label>Street Address</label><br>
-          <input type="text" name="address" required>
+          <input type="text" name="address" >
         </p>
         <p>
           <label>Zip Code</label><br>
@@ -18,7 +18,7 @@
         </p>
         <p>
           <label>City</label><br>
-          <input type="text" name="city" value="Bainbridge Island">
+          <input type="text" name="city" value="Seattle">
         </p>
         <p>
           <label>State</label><br>


### PR DESCRIPTION
So for example, if the user searches just by zip code, only the zip code address field appears on the results page with the WalkScore data for the zip code.